### PR TITLE
Add certifi to requirement list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     },
     #  scripts=['traderep'],
     # install_requires=['py_tr'],
-    install_requires=['coloredlogs', 'ecdsa', 'pygments', 'requests_futures', 'shtab', 'websockets>=10.1'],
+    install_requires=['coloredlogs', 'ecdsa', 'pygments', 'requests_futures', 'shtab', 'websockets>=10.1', 'certifi'],
     classifiers=[
         "License :: OSI Approved :: MIT License",
         'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
Commit 5f615bf introduced a dependency on certifi.

[cgoncalves@codfish ~]$ pytr help
Traceback (most recent call last):
  File "/home/cgoncalves/.local/bin/pytr", line 5, in <module>
    from pytr.main import main
  File "/home/cgoncalves/.local/lib/python3.10/site-packages/pytr/main.py", line 14, in <module>
    from pytr.account import login
  File "/home/cgoncalves/.local/lib/python3.10/site-packages/pytr/account.py", line 9, in <module>
    from pytr.api import TradeRepublicApi, CREDENTIALS_FILE
  File "/home/cgoncalves/.local/lib/python3.10/site-packages/pytr/api.py", line 32, in <module>
    import certifi
ModuleNotFoundError: No module named 'certifi'