### PR TITLE
added feature for auto calculating days since last download

### DIFF
--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -4,7 +4,8 @@ import logging
 import coloredlogs
 import json
 import requests
-from datetime import datetime
+from os import walk,stat, path
+from datetime import datetime, date
 from packaging import version
 
 
@@ -90,6 +91,16 @@ def check_version(installed_version):
         log.warning(f'Installed pytr version ({installed_version}) is outdated. Latest version is {latest_version}')
     else:
         log.info('pytr is up to date')
+
+def auto_calculate_since_timestamp(output_path):
+    # calculates the number of days from mtime of files in output dir
+    newest_file = date.fromtimestamp(1)
+    for root, dirs, files in walk(output_path):
+        for name in files:
+            if (name.split(".").pop() == "pdf"):
+                if (date.fromtimestamp(stat(path.join(root, name)).st_mtime) > newest_file):
+                    newest_file = date.fromtimestamp(stat(path.join(root, name)).st_mtime)
+    return (date.today()-newest_file).days
 
 
 class Timeline:


### PR DESCRIPTION
Using pytr I recognized it's always downloading all files regardless wether there are already files present in the target directory. So you get a lot of duplicate files if you don't set a proper --last_days parameter. One way is to calculate this day by hand and enter it or use a shell script to call pytr with a proper parameter.
For myself I thought it would be nice feature if pytr could do this automatically. So I decided to add this feature and thought this could be interesting for others, too.

What does my modification do?
I added a new parameter. Calling pytr with --auto_days specified leads to --last_days being ignored but checking all .pdf files in the target directory for the most recent date. I used st_mtime which is the last modication time. I didn't use st_ctime because on unix systems this can be updated through a metadata change.
After finding the most recent date it calculates the number of days between then and now and sets this as a value for --last_days respective since_timestamp
The calculation is done in utils.py.
If the difference is 0 it rejects execution as 0 would mean no limit. So this can only be used if you didn't download anything the same day.

I know it would be better to check the files for duplicates but this would require downloading them first. Another reason I didn't go for that approach is that I'm not sure about how to check to files for equality as I don't know what happens to document titles and so on if you purchase the same stock twice a day for example. If there is any information about this I would be happy to start another more precise approach.

In the end I would be happy if you consider this a useful addition and accept the pull request :)