### PR TITLE
added ability to check hashes of downloaded PDF-files to avoid duplic…

### DIFF
--- a/pytr/main.py
+++ b/pytr/main.py
@@ -63,6 +63,9 @@ def get_main_parser():
     parser_dl_docs.add_argument(
         '--last_days', help='Number of last days to include (use 0 get all days)', metavar='DAYS', default=0, type=int
     )
+    parser_dl_docs.add_argument(
+        '--check_hashes', help='Uses filehashes to avoid duplicates', action='store_true'
+    )
 
     parser_get_price_alarms = subparsers.add_parser(
         'get_price_alarms', parents=[parent_parser], help='Get overview of current price alarms'
@@ -126,7 +129,7 @@ def main():
         else:
             since_timestamp = (time.time() - (24 * 3600 * args.last_days)) * 1000
 
-        dl = DL(login(web=weblogin), args.output, args.format, since_timestamp=since_timestamp)
+        dl = DL(login(web=weblogin), args.output, args.format, since_timestamp=since_timestamp, check_hashes=args.check_hashes)
         asyncio.get_event_loop().run_until_complete(dl.dl_loop())
     elif args.command == 'set_price_alarms':
         # TODO

--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -6,7 +6,8 @@ import json
 import requests
 from datetime import datetime
 from packaging import version
-
+from os import walk, path
+from hashlib import md5
 
 log_level = None
 
@@ -90,6 +91,22 @@ def check_version(installed_version):
         log.warning(f'Installed pytr version ({installed_version}) is outdated. Latest version is {latest_version}')
     else:
         log.info('pytr is up to date')
+
+def collect_hashes(output_path):
+    # calculates the number of days from mtime of files in output dir
+    hashes = []
+    for root, dirs, files in walk(output_path):
+        for name in files:
+            if (name.split(".").pop() == "pdf"):
+                hashes.append(get_filehash(path.join(root, name)))
+    return hashes
+
+def get_filehash(path):
+    with open(path, 'rb') as f:
+        file_hash = md5()
+        while chunk := f.read(8192):
+            file_hash.update(chunk)
+        return file_hash.hexdigest()
 
 
 class Timeline:


### PR DESCRIPTION
As discussed in https://github.com/marzzzello/pytr/pull/22 there can be duplicates download files if you run more then once.

To avoid this I added an ability to check md5 hashes. The downside is you need to download the file first, check and delete. So I didn't add it as default. You need to enable it by using --check_hashes when callin pytr.

For me (400 documents) I didn't recognize a slower performance while saving to SSD drive. But I could be different with more documents I guess.