### PR TITLE
Replace portfolio operation with compactPortfolio

### DIFF
--- a/pytr/api.py
+++ b/pytr/api.py
@@ -384,6 +384,12 @@ class TradeRepublicApi:
     async def portfolio(self):
         return await self.subscribe({'type': 'portfolio'})
 
+    async def portfolio_status(self):
+        return await self.subscribe({'type': 'portfolioStatus'})
+
+    async def compact_portfolio(self):
+        return await self.subscribe({'type': 'compactPortfolio'})
+
     async def watchlist(self):
         return await self.subscribe({'type': 'watchlist'})
 

--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -107,18 +107,28 @@ class DL:
         filename = self.filename_fmt.format(
             iso_date=iso_date, time=time, title=titleText, subtitle=subtitleText, doc_num=doc_type_num, id=doc_id
         )
+        
+        filename_with_doc_id = filename + f' ({doc_id})'
+        
         if doc_type in ['Kontoauszug', 'Depotauszug']:
             filepath = directory / 'Abschlüsse' / f'{filename}' / f'{doc_type}.pdf'
+            filepath_with_doc_id = directory / 'Abschlüsse' / f'{filename_with_doc_id}' / f'{doc_type}.pdf'
         else:
             filepath = directory / doc_type / f'{filename}.pdf'
+            filepath_with_doc_id = directory / doc_type / f'{filename_with_doc_id}.pdf'
 
         filepath = sanitize_filepath(filepath, '_', 'auto')
+        filepath_with_doc_id = sanitize_filepath(filepath_with_doc_id, '_', 'auto')
 
         if filepath in self.filepaths:
-            self.log.debug(f'File {filepath} already in queue. Skipping...')
-            return
-        else:
-            self.filepaths.append(filepath)
+            self.log.debug(f'File {filepath} already in queue. Append document id {doc_id}...')
+            if filepath_with_doc_id in self.filepaths:
+                self.log.debug(f'File {filepath_with_doc_id} already in queue. Skipping...')
+                return
+            else:
+                filepath = filepath_with_doc_id
+
+        self.filepaths.append(filepath)
 
         if filepath.is_file() is False:
             doc_url_base = doc_url.split('?')[0]

--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -355,7 +355,12 @@ class Timeline:
                         if isSavingsPlan:
                             dl.dl_doc(doc, response['titleText'], response['subtitleText'], subfolder='Sparplan')
                         else:
-                            dl.dl_doc(doc, response['titleText'], response['subtitleText'])
+                            # In case of a stock transfer (Wertpapierübertrag) add additional information to the document title
+                            if response['titleText'] == 'Wertpapierübertrag':
+                                body = next(item['data']['body'] for item in self.events_with_docs if item['data']['id'] == response['id'])
+                                dl.dl_doc(doc, response['titleText'] + " - " + body, response['subtitleText'])
+                            else:
+                                dl.dl_doc(doc, response['titleText'], response['subtitleText'])
 
         if self.received_detail == self.num_timeline_details:
             self.log.info('Received all details')

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name='pytr',
-    version='0.1.5',
+    version='0.1.6',
     description='Use TradeRepublic in terminal',
     long_description=readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
TradeRupublic made some changes in API.
Replace single command `portfolio` with multiple commands: `compactPortfolio`, `instrument` and `tick`.

As sidecar change show the name of the ISIN.

It also copy changes from https://github.com/marzzzello/pytr/pull/29.

Steps:

First merge: https://github.com/marzzzello/pytr/pull/29
Then need to rebase this changes.

closes: #37 