### PR TITLE
Add option to save portfolio to csv

### DIFF
--- a/pytr/main.py
+++ b/pytr/main.py
@@ -94,12 +94,15 @@ def get_main_parser():
     parser_dl_docs.add_argument('--universal', help='Platform independent file names', action='store_true')
     # portfolio
     info = 'Show current portfolio'
-    parser_cmd.add_parser(
+    parser_portfolio = parser_cmd.add_parser(
         'portfolio',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         parents=[parser_login_args],
         help=info,
         description=info,
+    )
+    parser_portfolio.add_argument(
+        '-o', '--output', help='Output path of CSV file', metavar='OUTPUT', type=Path
     )
     # details
     info = 'Get details for an ISIN'
@@ -214,7 +217,10 @@ def main():
     elif args.command == 'details':
         Details(login(phone_no=args.phone_no, pin=args.pin, web=not args.applogin), args.isin).get()
     elif args.command == 'portfolio':
-        Portfolio(login(phone_no=args.phone_no, pin=args.pin, web=not args.applogin)).get()
+        p = Portfolio(login(phone_no=args.phone_no, pin=args.pin, web=not args.applogin), args.output)
+        p.get()
+        if args.output is not None:
+            p.portfolio_to_csv()
     elif args.command == 'export_transactions':
         export_transactions(args.input, args.output, args.lang)
     elif args.version:

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -4,8 +4,9 @@ from pytr.utils import preview
 
 
 class Portfolio:
-    def __init__(self, tr):
+    def __init__(self, tr, output_path):
         self.tr = tr
+        self.output_path = output_path
 
     async def portfolio_loop(self):
         recv = 0
@@ -75,6 +76,20 @@ class Portfolio:
                 pos['name'] = response['shortName']
             else:
                 print(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
+
+    def portfolio_to_csv(self):
+        positions = self.portfolio['positions']
+        csv_lines = []
+        for pos in sorted(positions, key=lambda x: x['netSize'], reverse=True):
+            csv_lines.append(
+                f"{pos['name']};{pos['instrumentId']};{float(pos['averageBuyIn']):.2f};{float(pos['netValue']):.2f}"
+            )
+        
+        with open(self.output_path, 'w', encoding='utf-8') as f:
+            f.write('Name;ISIN;avgCost;netValue\n')
+            f.write('\n'.join(csv_lines))
+        
+        print(f'Wrote {len(csv_lines) + 1} lines to {self.output_path}')
 
     def overview(self):
         # for x in ['netValue', 'unrealisedProfit', 'unrealisedProfitPercent', 'unrealisedCost']:

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -4,10 +4,9 @@ from pytr.utils import preview
 
 
 class Portfolio:
-    def __init__(self, tr, output_path):
+    def __init__(self, tr):
         self.tr = tr
-        self.output_path = output_path
-
+        
     async def portfolio_loop(self):
         recv = 0
         # await self.tr.portfolio()
@@ -77,7 +76,7 @@ class Portfolio:
             else:
                 print(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
 
-    def portfolio_to_csv(self):
+    def portfolio_to_csv(self, output_path):
         positions = self.portfolio['positions']
         csv_lines = []
         for pos in sorted(positions, key=lambda x: x['netSize'], reverse=True):
@@ -85,7 +84,7 @@ class Portfolio:
                 f"{pos['name']};{pos['instrumentId']};{float(pos['averageBuyIn']):.2f};{float(pos['netValue']):.2f}"
             )
         
-        with open(self.output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, 'w', encoding='utf-8') as f:
             f.write('Name;ISIN;avgCost;netValue\n')
             f.write('\n'.join(csv_lines))
         

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -6,7 +6,7 @@ from pytr.utils import preview
 class Portfolio:
     def __init__(self, tr):
         self.tr = tr
-        
+
     async def portfolio_loop(self):
         recv = 0
         # await self.tr.portfolio()


### PR DESCRIPTION
- add portfolio_to_csv method to Portfolio class
- extend argument parsing with path option for saving csv
- also add help string to -o option
- portfolio_to_csv executes after get() method when path for saving csv is provided

**Core idea:**
With this option, when providing the `-o` or `--output` option (and a filepath) to the portfolio command, the key information of the portfolio is exported to a csv file. This eases the use of net value and ISIN etc. for further analysis, since csv format is easier to use when needing further analysis than the formatted string output in the CLI.