### PR TITLE
Add parameters for cookies and credential file to TradeRepublicApi constructor

### DIFF
--- a/pytr/api.py
+++ b/pytr/api.py
@@ -65,6 +65,9 @@ class TradeRepublicApi:
     _subscription_id_counter = 1
     _previous_responses = {}
     subscriptions = {}
+    
+    _credentials_file = CREDENTIALS_FILE
+    _cookies_file = COOKIES_FILE
 
     @property
     def session_token(self):
@@ -79,21 +82,27 @@ class TradeRepublicApi:
         self._session_token_expires_at = time.time() + 290
         self._session_token = val
 
-    def __init__(self, phone_no=None, pin=None, keyfile=None, locale='de', save_cookies=False):
+    def __init__(self, phone_no=None, pin=None, keyfile=None, locale='de', save_cookies=False, credentials_file = None, cookies_file = None):
         self.log = get_logger(__name__)
         self._locale = locale
         self._save_cookies = save_cookies
+        
+        self._credentials_file = pathlib.Path(credentials_file) if credentials_file else CREDENTIALS_FILE
+        self._cookies_file = pathlib.Path(cookies_file) if cookies_file else COOKIES_FILE
+        
         if not (phone_no and pin):
             try:
-                with open(CREDENTIALS_FILE, 'r') as f:
+                with open(self._credentials_file, 'r') as f:
                     lines = f.readlines()
                 self.phone_no = lines[0].strip()
                 self.pin = lines[1].strip()
             except FileNotFoundError:
-                raise ValueError(f'phone_no and pin must be specified explicitly or via {CREDENTIALS_FILE}')
+                raise ValueError(f'phone_no and pin must be specified explicitly or via {self._credentials_file}')
         else:
             self.phone_no = phone_no
             self.pin = pin
+        
+        
 
         self.keyfile = keyfile if keyfile else KEY_FILE
         try:
@@ -105,7 +114,7 @@ class TradeRepublicApi:
         self._websession = requests.Session()
         self._websession.headers = self._default_headers_web
         if self._save_cookies:
-            self._websession.cookies = MozillaCookieJar(COOKIES_FILE)
+            self._websession.cookies = MozillaCookieJar(self._cookies_file)
 
     def initiate_device_reset(self):
         self.sk = SigningKey.generate(curve=NIST256p, hashfunc=hashlib.sha512)
@@ -224,7 +233,7 @@ class TradeRepublicApi:
             return False
 
         # Only attempt to load if the cookie file exists.
-        if COOKIES_FILE.exists():
+        if self._cookies_file.exists():
             # Loads session cookies too (expirydate=0).
             self._websession.cookies.load(ignore_discard=True, ignore_expires=True)
             self._weblogin = True


### PR DESCRIPTION
* allows to overwrite the path parameters for cookie and credential file in the constructor of TradeRepublicApi
* If they are not overwritten they default to the current parameters

Background: 
* I'm using the project as an api in a docker container and I want to change the hardcoded paths to point to another directory
* It was already possible to point to the key file, but not cookies or credentials